### PR TITLE
新規登録機能の改修

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,12 +87,12 @@ Things you may want to cover:
 |first_name|string|null: false|
 |family_name_kana|string|null: false|
 |first_name_kana|string|null: false|
-|postal_code|integer|null: false, limit: 8|
+|postal_code|string|null: false, limit: 8|
 |prefecture|string|null: false|
 |city|string|null: false|
 |house_number|string|null: false|
 |building_name|string|
-|telephone|integer|
+|telephone|string|
 |user_id|reference|null: false, foreign_key: true|
 
 ### Association

--- a/app/assets/stylesheets/modules/_user.scss
+++ b/app/assets/stylesheets/modules/_user.scss
@@ -72,6 +72,8 @@
   margin: 30px 0;
   &__label--normal {
     @include MarginSpace();
+    text-align: left;
+    margin-left: 103px;
   }
   input {
     border: 1px solid #ccc;
@@ -81,6 +83,16 @@
     height: 48px;
     padding: 0 16px;
     width: 60%;
+    margin-bottom: 18px;
+  }
+  select {
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    font-family: inherit;
+    font-size: inherit;
+    height: 48px;
+    padding: 0 16px;
+    width: 19%;
     margin-bottom: 18px;
   }
   &__input--small {

--- a/app/assets/stylesheets/modules/_user.scss
+++ b/app/assets/stylesheets/modules/_user.scss
@@ -73,10 +73,20 @@
   &__label--normal {
     @include MarginSpace();
   }
+  input {
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    font-family: inherit;
+    font-size: inherit;
+    height: 48px;
+    padding: 0 16px;
+    width: 60%;
+    margin-bottom: 18px;
+  }
   &__input--small {
     input {
       margin: 0 5px;
-      width: 85px;
+      width: 140px;
     }
   }
   span {

--- a/app/assets/stylesheets/modules/_user.scss
+++ b/app/assets/stylesheets/modules/_user.scss
@@ -33,9 +33,14 @@
     margin: 0 auto;
     text-align: center;
     background-color: white;
-    &__title {
+    &__top {
       padding-bottom: 20px;
       font-size: 26px;
+      font-weight: bold;
+    }
+    &__title {
+      padding-bottom: 20px;
+      font-size: 20px;
       font-weight: bold;
       border-bottom: solid #ddd 1px;
     }

--- a/app/assets/stylesheets/modules/_user.scss
+++ b/app/assets/stylesheets/modules/_user.scss
@@ -72,6 +72,8 @@
   margin: 30px 0;
   &__label--normal {
     @include MarginSpace();
+    font-size: 14px;
+    font-weight: bold;
     text-align: left;
     margin-left: 103px;
   }

--- a/app/assets/stylesheets/modules/_user.scss
+++ b/app/assets/stylesheets/modules/_user.scss
@@ -95,6 +95,9 @@
     width: 19%;
     margin-bottom: 18px;
   }
+  .Prefecture {
+    width: 60%;
+  }
   &__input--small {
     input {
       margin: 0 5px;

--- a/app/assets/stylesheets/modules/_user.scss
+++ b/app/assets/stylesheets/modules/_user.scss
@@ -77,7 +77,12 @@
   span {
     margin-left: 5px;
     font-size: 14px;
-    color: red;
+  }
+  .mandatory {
+    @include mandatory();
+  }
+  .optional {
+    @include optional();
   }
 }
 
@@ -96,3 +101,4 @@
   margin-top: 30px;
   font-size: 14px;
 }
+

--- a/app/controllers/signups_controller.rb
+++ b/app/controllers/signups_controller.rb
@@ -58,7 +58,7 @@ class SignupsController < ApplicationController
   end
 
   def destination_params
-    params.require(:destination).permit(:family_name, :first_name, :family_name_kana, :first_name_kana, :postal_code, :prefecture, :city, :house_number, :building_name, :telephone)
+    params.require(:destination).permit(:family_name, :first_name, :family_name_kana, :first_name_kana, :postal_code, :prefecture_id, :city, :house_number, :building_name, :telephone)
   end
 
 end

--- a/app/models/destination.rb
+++ b/app/models/destination.rb
@@ -25,5 +25,5 @@ class Destination < ApplicationRecord
   validates :prefecture, presence: true
   validates :city, presence: true
   validates :house_number, presence: true
-  validates :telephone, length: { in: 10..11, message: "は10桁または11桁で入力してください" }
+  validates :telephone, length: { in: 10..11, message: "は10桁または11桁で入力してください" }, numericality: :only_integer
 end

--- a/app/models/destination.rb
+++ b/app/models/destination.rb
@@ -27,5 +27,7 @@ class Destination < ApplicationRecord
   validates :prefecture, presence: true
   validates :city, presence: true
   validates :house_number, presence: true
-  validates :telephone, length: { in: 10..11, message: "は10桁または11桁で入力してください" }, numericality: :only_integer
+  with_options unless: -> { telephone == "" } do
+    validates :telephone, length: { in: 10..11, message: "は10桁または11桁で入力してください" }, numericality: :only_integer
+  end
 end

--- a/app/models/destination.rb
+++ b/app/models/destination.rb
@@ -1,7 +1,7 @@
 class Destination < ApplicationRecord
   extend ActiveHash::Associations::ActiveRecordExtensions
   belongs_to :user, optional: true
-  belongs_to :prefecture
+  belongs_to_active_hash :prefecture
 
   validates :family_name, presence: true,
     format: {

--- a/app/models/destination.rb
+++ b/app/models/destination.rb
@@ -1,5 +1,7 @@
 class Destination < ApplicationRecord
+  extend ActiveHash::Associations::ActiveRecordExtensions
   belongs_to :user, optional: true
+  belongs_to :prefecture
 
   validates :family_name, presence: true,
     format: {

--- a/app/models/prefecture.rb
+++ b/app/models/prefecture.rb
@@ -1,4 +1,4 @@
-class Prerecture < ActiveHash::Base
+class Prefecture < ActiveHash::Base
   self.data = [
     {id: 1, name: '北海道'}, {id: 2, name: '青森県'}, {id: 3, name: '岩手県'},
     {id: 4, name: '宮城県'}, {id: 5, name: '秋田県'}, {id: 6, name: '山形県'},

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -7,7 +7,7 @@
       新規登録画面
     = form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f|
       .ErrorMessages
-        = devise_error_messages!
+        = render '../../signups/error_messages', model: f.object
       .FormField
         .FormField__label--normal
           = f.label :nick_name

--- a/app/views/signups/step1.html.haml
+++ b/app/views/signups/step1.html.haml
@@ -3,8 +3,10 @@
     = link_to root_path do
       = image_tag 'logo/logo.png', alt: 'furima'
   .AccountPage__form
+    .AccountPage__form__top
+      新規登録画面 1/3
     .AccountPage__form__title
-      新規登録画面
+      会員情報入力
     = form_for @user, url: step1_signups_path, method: :post do |f|
       .ErrorMessages
         = render 'error_messages', model: f.object

--- a/app/views/signups/step1.html.haml
+++ b/app/views/signups/step1.html.haml
@@ -11,26 +11,26 @@
       .FormField
         .FormField__label--normal
           = f.label :nick_name
-          %span 必須
+          %span.mandatory 必須
         .FormField__input--normal
           = f.text_field :nick_name, autofocus: true
       .FormField
         .FormField__label--normal
           = f.label :email
-          %span 必須
+          %span.mandatory 必須
         .FormField__input--normal
           = f.email_field :email
       .FormField
         .FormField__label--normal
           = f.label :password
           %i (英数字7文字以上)
-          %span 必須
+          %span.mandatory 必須
         .FormField__input--normal
           = f.password_field :password, autocomplete: "off"
       .FormField
         .FormField__label--normal
           = f.label :password_confirmation
-          %span 必須
+          %span.mandatory 必須
         .FormField__input--normal
           = f.password_field :password_confirmation, autocomplete: "off"
       .actions

--- a/app/views/signups/step1.html.haml
+++ b/app/views/signups/step1.html.haml
@@ -15,17 +15,17 @@
           = f.label :nick_name
           %span.mandatory 必須
         .FormField__input--normal
-          = f.text_field :nick_name, autofocus: true
+          = f.text_field :nick_name, autofocus: true, placeholder: 'フリマくん'
       .FormField
         .FormField__label--normal
           = f.label :email
           %span.mandatory 必須
         .FormField__input--normal
-          = f.email_field :email
+          = f.email_field :email, placeholder: 'sample@sample.com'
       .FormField
         .FormField__label--normal
           = f.label :password
-          %i (英数字7文字以上)
+          (英数字7文字以上)
           %span.mandatory 必須
         .FormField__input--normal
           = f.password_field :password, autocomplete: "off"

--- a/app/views/signups/step2.html.haml
+++ b/app/views/signups/step2.html.haml
@@ -3,8 +3,10 @@
     = link_to root_path do
       = image_tag 'logo/logo.png', alt: 'furima'
   .AccountPage__form
+    .AccountPage__form__top
+      新規登録画面 2/3
     .AccountPage__form__title
-      新規登録画面
+      本人確認情報入力
     = form_for @profile, url: step2_signups_path, method: :post do |f|
       .ErrorMessages
         = render 'error_messages', model: f.object

--- a/app/views/signups/step2.html.haml
+++ b/app/views/signups/step2.html.haml
@@ -11,21 +11,21 @@
       .FormField
         .FormField__label--normal
           お名前
-          %span 必須
+          %span.mandatory 必須
         .FormField__input--small
           = f.text_field :family_name, autofocus: true, placeholder: '姓'
           = f.text_field :first_name, autofocus: true, placeholder: '名'
       .FormField
         .FormField__label--normal
           お名前（カナ）
-          %span 必須
+          %span.mandatory 必須
         .FormField__input--small
           = f.text_field :family_name_kana, autofocus: true, placeholder: 'セイ'
           = f.text_field :first_name_kana, autofocus: true, placeholder: 'メイ'
       .FormField
         .FormField__label--normal
           = f.label :birthday, "生年月日"
-          %span 必須
+          %span.mandatory 必須
         .FormField__input--normal
           = f.date_select :birthday, use_month_numbers: true,start_year: 1930, end_year: (Time.now.year), default: Date.new(1989, 1, 1)
       .actions

--- a/app/views/signups/step3.html.haml
+++ b/app/views/signups/step3.html.haml
@@ -32,10 +32,10 @@
           = f.text_field :postal_code, autofocus: true, placeholder: '0001111'
       .FormField
         .FormField__label--normal
-          = f.label :prefecture
+          = f.label :prefecture_id
           %span.mandatory 必須
         .FormField__input--normal
-          = f.text_field :prefecture, autofocus: true, placeholder: '○○県'
+          = f.collection_select :prefecture_id, Prefecture.all, :id, :name, {prompt: "選択してください"}, class: 'Prefecture'
       .FormField
         .FormField__label--normal
           = f.label :city

--- a/app/views/signups/step3.html.haml
+++ b/app/views/signups/step3.html.haml
@@ -53,7 +53,7 @@
           = f.label :building_name
           %span.optional 任意
         .FormField__input--normal
-          = f.text_field :building_name, autofocus: true
+          = f.text_field :building_name, autofocus: true, placeholder: 'コーポフリマ201号'
       .FormField
         .FormField__label--normal
           = f.label :telephone, "電話番号（ハイフンなし）"

--- a/app/views/signups/step3.html.haml
+++ b/app/views/signups/step3.html.haml
@@ -3,8 +3,10 @@
     = link_to root_path do
       = image_tag 'logo/logo.png', alt: 'furima'
   .AccountPage__form
+    .AccountPage__form__top
+      新規登録画面 3/3
     .AccountPage__form__title
-      新規登録画面
+      発送先及び送付先情報入力
     = form_for @destination, url: step3_signups_path, method: :post do |f|
       .ErrorMessages
         = render 'error_messages', model: f.object

--- a/app/views/signups/step3.html.haml
+++ b/app/views/signups/step3.html.haml
@@ -11,49 +11,51 @@
       .FormField
         .FormField__label--normal
           お名前
-          %span 必須
+          %span.mandatory 必須
         .FormField__input--small
           = f.text_field :family_name, autofocus: true, placeholder: '姓'
           = f.text_field :first_name, autofocus: true, placeholder: '名'
       .FormField
         .FormField__label--normal
           お名前（カナ）
-          %span 必須
+          %span.mandatory 必須
         .FormField__input--small
           = f.text_field :family_name_kana, autofocus: true, placeholder: 'セイ'
           = f.text_field :first_name_kana, autofocus: true, placeholder: 'メイ'
       .FormField
         .FormField__label--normal
           = f.label :postal_code, "郵便番号（ハイフンなし）"
-          %span 必須
+          %span.mandatory 必須
         .FormField__input--normal
           = f.text_field :postal_code, autofocus: true, placeholder: '0001111'
       .FormField
         .FormField__label--normal
           = f.label :prefecture
-          %span 必須
+          %span.mandatory 必須
         .FormField__input--normal
           = f.text_field :prefecture, autofocus: true, placeholder: '○○県'
       .FormField
         .FormField__label--normal
           = f.label :city
-          %span 必須
+          %span.mandatory 必須
         .FormField__input--normal
           = f.text_field :city, autofocus: true, placeholder: '○○市○○町'
       .FormField
         .FormField__label--normal
           = f.label :house_number
-          %span 必須
+          %span.mandatory 必須
         .FormField__input--normal
           = f.text_field :house_number, autofocus: true, placeholder: '○丁目○-○○'
       .FormField
         .FormField__label--normal
           = f.label :building_name
+          %span.optional 任意
         .FormField__input--normal
           = f.text_field :building_name, autofocus: true
       .FormField
         .FormField__label--normal
           = f.label :telephone, "電話番号（ハイフンなし）"
+          %span.optional 任意
         .FormField__input--normal
           = f.text_field :telephone, autofocus: true, placeholder: '00011112222'
       .actions

--- a/app/views/signups/step3.html.haml
+++ b/app/views/signups/step3.html.haml
@@ -27,7 +27,7 @@
           = f.label :postal_code, "郵便番号（ハイフンなし）"
           %span 必須
         .FormField__input--normal
-          = f.number_field :postal_code, autofocus: true, placeholder: '0001111'
+          = f.text_field :postal_code, autofocus: true, placeholder: '0001111'
       .FormField
         .FormField__label--normal
           = f.label :prefecture

--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -39,6 +39,7 @@ ja:
         first_name_kana: 名(カナ)
         postal_code: 郵便番号
         prefecture: 都道府県
+        prefecture_id: 都道府県
         city: 市区町村
         house_number: 番地
         building_name: マンション名など

--- a/db/migrate/20201008055345_change_data_postal_code_to_destinations.rb
+++ b/db/migrate/20201008055345_change_data_postal_code_to_destinations.rb
@@ -1,0 +1,9 @@
+class ChangeDataPostalCodeToDestinations < ActiveRecord::Migration[6.0]
+  def up
+    change_column :destinations, :postal_code, :string
+  end
+
+  def down
+    change_column :destinations, :postal_code, :integer
+  end
+end

--- a/db/migrate/20201008080810_rename_and_change_data_prefecture_to_destinations.rb
+++ b/db/migrate/20201008080810_rename_and_change_data_prefecture_to_destinations.rb
@@ -1,0 +1,11 @@
+class RenameAndChangeDataPrefectureToDestinations < ActiveRecord::Migration[6.0]
+  def up
+    change_column :destinations, :prefecture, :integer
+    rename_column :destinations, :prefecture, :prefecture_id
+  end
+
+  def down
+    rename_column :destinations, :prefecture_id, :prefecture
+    change_column :destinations, :postal_code, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_10_08_055345) do
+ActiveRecord::Schema.define(version: 2020_10_08_080810) do
 
   create_table "brands", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
@@ -31,7 +31,7 @@ ActiveRecord::Schema.define(version: 2020_10_08_055345) do
     t.string "family_name_kana", null: false
     t.string "first_name_kana", null: false
     t.string "postal_code", null: false
-    t.string "prefecture", null: false
+    t.integer "prefecture_id", null: false
     t.string "city", null: false
     t.string "house_number", null: false
     t.string "building_name"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_10_08_023111) do
+ActiveRecord::Schema.define(version: 2020_10_08_055345) do
 
   create_table "brands", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
@@ -30,7 +30,7 @@ ActiveRecord::Schema.define(version: 2020_10_08_023111) do
     t.string "first_name", null: false
     t.string "family_name_kana", null: false
     t.string "first_name_kana", null: false
-    t.bigint "postal_code", null: false
+    t.string "postal_code", null: false
     t.string "prefecture", null: false
     t.string "city", null: false
     t.string "house_number", null: false

--- a/spec/factories/destinations.rb
+++ b/spec/factories/destinations.rb
@@ -1,12 +1,12 @@
 FactoryBot.define do
-
+  
   factory :destination do
     family_name      {"姓"}
     first_name       {"名"}
     family_name_kana {"セイ"}
     first_name_kana  {"メイ"}
-    postal_code      {1234567}
-    prefecture       {"高知県高知市"}
+    postal_code      {"1234567"}
+    prefecture       {Prefecture.find_by_id(1)}
     city             {"一ツ橋町"}
     house_number     {"1丁目"}
     building_name    {""}

--- a/spec/models/destinations_spec.rb
+++ b/spec/models/destinations_spec.rb
@@ -72,25 +72,19 @@ describe Destination do
     end
 
     it "住所が6桁だとエラー" do
-      @destination.postal_code = 123456
+      @destination.postal_code = "123456"
       @destination.valid?
       expect(@destination.errors[:postal_code]).to include("は7文字で入力してください")
     end
 
     it "住所が8桁だとエラー" do
-      @destination.postal_code = 12345678
-      @destination.valid?
-      expect(@destination.errors[:postal_code]).to include("は7文字で入力してください")
-    end
-
-    it "住所が文字だとエラー" do
-      @destination.postal_code = "一二三四五六七"
+      @destination.postal_code = "12345678"
       @destination.valid?
       expect(@destination.errors[:postal_code]).to include("は7文字で入力してください")
     end
 
     it "都道府県が未入力だとエラー" do
-      @destination.prefecture = ""
+      @destination.prefecture = nil
       @destination.valid?
       expect(@destination.errors[:prefecture]).to include("を入力してください")
     end
@@ -105,6 +99,18 @@ describe Destination do
       @destination.house_number = ""
       @destination.valid?
       expect(@destination.errors[:house_number]).to include("を入力してください")
+    end
+
+    it "電話番号が9桁だとエラー" do
+      @destination.telephone = "123456789"
+      @destination.valid?
+      expect(@destination.errors[:telephone]).to include("は10桁または11桁で入力してください")
+    end
+
+    it "電話番号が12桁だとエラー" do
+      @destination.telephone = "123456789012"
+      @destination.valid?
+      expect(@destination.errors[:telephone]).to include("は10桁または11桁で入力してください")
     end
 
   end

--- a/spec/models/destinations_spec.rb
+++ b/spec/models/destinations_spec.rb
@@ -83,6 +83,12 @@ describe Destination do
       expect(@destination.errors[:postal_code]).to include("は7文字で入力してください")
     end
 
+    it "住所が文字だとエラー" do
+      @destination.postal_code = "一二三四五六七"
+      @destination.valid?
+      expect(@destination.errors[:postal_code]).to include("は数値で入力してください")
+    end
+
     it "都道府県が未入力だとエラー" do
       @destination.prefecture = nil
       @destination.valid?
@@ -111,6 +117,12 @@ describe Destination do
       @destination.telephone = "123456789012"
       @destination.valid?
       expect(@destination.errors[:telephone]).to include("は10桁または11桁で入力してください")
+    end
+
+    it "電話番号が文字だとエラー" do
+      @destination.telephone = "一二三四五六七八九十"
+      @destination.valid?
+      expect(@destination.errors[:telephone]).to include("は数値で入力してください")
     end
 
   end


### PR DESCRIPTION
# What
新規登録画面および新規登録サーバーサイドの改修

## 画面の変更
上部のメッセージ「新規登録画面」→「新規登録画面 1/3」に変更
上部のメッセージに登録内容がわかるメッセージを追加「会員情報入力」etc..
入力内容のフォントサイズを変更
各入力フォームのデザインを変更
「必須」のデザイン変更および「任意」のアイコンを追加

## 送付先テーブルの変更
郵便番号カラムを「string型」に変更
都道府県カラムを「active_hash」に変更
電話番号カラムを「string型」に変更（当該ブランチの履歴にはないですが）

## モデル変更
電話番号をnullまたは10~11桁の数値のみ受け付けるようにバリデーションを追加